### PR TITLE
Warnings partial cleanup + network visualization

### DIFF
--- a/virusnetwork/.gitignore
+++ b/virusnetwork/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.idea

--- a/virusnetwork/Cargo.toml
+++ b/virusnetwork/Cargo.toml
@@ -9,9 +9,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rust-ab = {git="https://github.com/rust-ab/rust-ab.git"}
-bevy_prototype_lyon = "0.3.1"
-
+rust-ab = {path="../../abm"}
 
 [features]
 visualization = ["rust-ab/visualization"]

--- a/virusnetwork/Cargo.toml
+++ b/virusnetwork/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rust-ab = {path="../../abm"}
+rust-ab = {git="https://github.com/rust-ab/rust-ab.git"}
 
 [features]
 visualization = ["rust-ab/visualization"]

--- a/virusnetwork/index.html
+++ b/virusnetwork/index.html
@@ -1,0 +1,28 @@
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <style>
+        body {
+            background: linear-gradient(
+                    135deg,
+                    white 0%,
+                    white 49%,
+                    black 49%,
+                    black 51%,
+                    white 51%,
+                    white 100%
+            ) repeat;
+            background-size: 20px 20px;
+        }
+
+        canvas {
+            background-color: white;
+        }
+    </style>
+</head>
+<script type="module">
+    import init from './target/wasm.js'
+
+    init()
+</script>
+</html>

--- a/virusnetwork/src/main.rs
+++ b/virusnetwork/src/main.rs
@@ -1,16 +1,27 @@
 extern crate rust_ab;
 
-use model::{node::{self, NetNode}, state::{INITIAL_INFECTED_PROB, INIT_EDGE}};
-use model::node::{NodeStatus, NodeStatus::*};
-use model::state::EpidemicNetworkState;
-use rust_ab::engine::{field::network::EdgeOptions::*};
-use rust_ab::engine::field::network::*;
+
+use rust_ab::rand;
+use rust_ab::{engine::location::Real2D};
+use rust_ab::bevy::prelude::IntoSystem;
 use rust_ab::engine::schedule::*;
 use rust_ab::rand::Rng;
-use rust_ab::{engine::agent::Agent, rand};
-use rust_ab::{engine::location::Real2D, preferential_attachment_BA};
-use rust_ab::{ explore, simulate };
-use std::{time::Instant, u128};
+use rust_ab::visualization::field::network::NetworkRender;
+
+// Visualization specific imports
+#[cfg(any(feature = "visualization", feature = "visualization_wasm"))]
+use {
+    crate::visualization::vis_state::VisState,
+    rust_ab::bevy::prelude::Color,
+    rust_ab::visualization::visualization::Visualization,
+};
+use model::{node::NetNode, state::INITIAL_INFECTED_PROB};
+use model::node::{NodeStatus, NodeStatus::*};
+use model::state::EpidemicNetworkState;
+
+use crate::model::epidemic_network::EpidemicNetwork;
+
+//use rust_ab::{ explore, simulate };
 
 mod model;
 
@@ -30,20 +41,20 @@ fn main() {
 
     let nodes_set = gen_nodes(&mut state, &mut schedule);
     preferential_attachment_BA!(nodes_set, state.network, NetNode, String, INIT_EDGE);
-    
-    for node in state.network.edges.keys(){
+
+    for node in state.network.edges.keys() {
         println!("Node {} has {} edges", node.id, state.network.getEdges(node).unwrap().len());
     }
 
-   // let p = Parameters::FloatParam(2.1, 3.2, 5.3);
-/*     let model_output = |&state| {
-        //bam
-        //compute number of infected agents on state.network = infected
-        // compute number of recoverd agents on state.network = recovered
-        return (infected, recoverd);
-    }
+    // let p = Parameters::FloatParam(2.1, 3.2, 5.3);
+    /*     let model_output = |&state| {
+            //bam
+            //compute number of infected agents on state.network = infected
+            // compute number of recoverd agents on state.network = recovered
+            return (infected, recoverd);
+        }
 
-    exploration_output = explore!(STEP, schedule, NetNode, state, model_output); */
+        exploration_output = explore!(STEP, schedule, NetNode, state, model_output); */
     //table exploration_output
     //each row 
     // params list + output list
@@ -51,12 +62,12 @@ fn main() {
     //inside explore!
     //model_configurations = compute_paramentes(state)
     //for params in model_configurations do in parallel
-        //simulate!(STEP....)
-        //sim_output = model_output(state)
+    //simulate!(STEP....)
+    //sim_output = model_output(state)
     //end
     //results.append(sim:_output)
 
-   // exploration_output = explore!(STEP, schedule, NetNode, state, model_output, algorithm);
+    // exploration_output = explore!(STEP, schedule, NetNode, state, model_output, algorithm);
 
     simulate!(STEP, schedule, NetNode, state);
 }
@@ -87,30 +98,16 @@ fn gen_nodes(state: &mut EpidemicNetworkState, schedule: &mut Schedule<NetNode>)
         );
 
         state.field1.set_object_location(node, node.pos);
-        state.network.addNode(&node);
+        state.network.network.add_node(&node);
         schedule.schedule_repeating(node, 0.0, 0);
 
         nodes_set.push(node);
     }
-    let t = state.network.edges.len();
+    let t = state.network.network.edges.len();
     println!("Nodes in the network:\t\t{}", t);
     nodes_set
 }
 
-
-
-// Visualization specific imports
-#[cfg(any(feature = "visualization", feature = "visualization_wasm"))]
-use {
-    rust_ab::{bevy::{DefaultPlugins, prelude::{Commands, Msaa, OrthographicCameraBundle, Transform}}, engine::field::network::EdgeOptions},
-    rust_ab::visualization::visualization::Visualization,
-    crate::visualization::vis_state::VisState,
-    rust_ab::bevy::prelude::Color,
-    rust_ab::bevy::prelude::IntoSystem,
-    rust_ab::visualization::field::number_grid_2d::BatchRender,
-    bevy_prototype_lyon::prelude::*
-
-};
 
 #[cfg(any(feature = "visualization", feature = "visualization_wasm"))]
 mod visualization;
@@ -119,39 +116,15 @@ mod visualization;
 #[cfg(any(feature = "visualization", feature = "visualization_wasm"))]
 fn main() {
     // Initialize the simulation and its visualization here.
-    let mut schedule: Schedule<NetNode> = Schedule::new();
-    let mut state = EpidemicNetworkState::new(WIDTH, HEIGTH, DISCRETIZATION, TOROIDAL);
+    let schedule: Schedule<NetNode> = Schedule::new();
+    let state = EpidemicNetworkState::new(WIDTH, HEIGTH, DISCRETIZATION, TOROIDAL);
 
-    
     let mut app = Visualization::default()
         .with_window_dimensions(800., 800.)
         .with_simulation_dimensions(500., 500.)
-        .with_background_color(Color::rgb(0., 0., 0.))
+        .with_background_color(Color::rgb(255., 255., 255.))
         .setup::<NetNode, VisState>(VisState, state, schedule);
 
-    app.add_plugin(ShapePlugin);
-
-    app.add_startup_system(setup.system());
+    app.add_system(EpidemicNetwork::render.system());
     app.run();
-
-}
-
-#[cfg(any(feature = "visualization", feature = "visualization_wasm"))]
-fn setup(mut commands: Commands) {
-    let shape = shapes::RegularPolygon {
-        sides: 6,
-        feature: shapes::RegularPolygonFeature::Radius(20.0),
-        ..shapes::RegularPolygon::default()
-    };
-
-    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
-    commands.spawn_bundle(GeometryBuilder::build_as(
-        &shape,
-        ShapeColors::outlined(Color::RED, Color::AZURE),
-        DrawMode::Outlined {
-            fill_options: FillOptions::default(),
-            outline_options: StrokeOptions::default().with_line_width(10.0),
-        },
-        Transform::default(),
-    ));
 }

--- a/virusnetwork/src/model/epidemic_network.rs
+++ b/virusnetwork/src/model/epidemic_network.rs
@@ -1,0 +1,15 @@
+use rust_ab::engine::field::network::Network;
+
+use crate::model::node::NetNode;
+
+pub struct EpidemicNetwork {
+    pub network: Network<NetNode, String>,
+}
+
+impl EpidemicNetwork {
+    pub fn new() -> EpidemicNetwork {
+        EpidemicNetwork {
+            network: Network::new(false),
+        }
+    }
+}

--- a/virusnetwork/src/model/mod.rs
+++ b/virusnetwork/src/model/mod.rs
@@ -1,2 +1,3 @@
 pub mod node;
 pub mod state;
+pub mod epidemic_network;

--- a/virusnetwork/src/model/state.rs
+++ b/virusnetwork/src/model/state.rs
@@ -1,7 +1,8 @@
-use crate::model::node::NetNode;
-
-use rust_ab::engine::field::{field::Field, field_2d::Field2D, network::Network};
+use rust_ab::engine::field::{field::Field, field_2d::Field2D};
 use rust_ab::engine::state::State;
+
+use crate::model::epidemic_network::EpidemicNetwork;
+use crate::model::node::NetNode;
 
 ///Initial infected nodes
 pub static INITIAL_INFECTED_PROB: f64 = 0.01;
@@ -17,11 +18,10 @@ pub static RECOVERY_CHANCE: f64 = 0.30;
 pub static GAIN_RESISTENCE_CHANCE: f64 = 0.20;
 
 
-
 pub struct EpidemicNetworkState {
-    pub step: u128,
+    pub step: usize,
     pub field1: Field2D<NetNode>,
-    pub network: Network<NetNode, String>,
+    pub network: EpidemicNetwork,
 }
 
 impl EpidemicNetworkState {
@@ -29,13 +29,14 @@ impl EpidemicNetworkState {
         EpidemicNetworkState {
             step: 0,
             field1: Field2D::new(w, h, d, t),
-            network: Network::new(false),
+            network: EpidemicNetwork::new(),
         }
     }
 }
 
-impl State for EpidemicNetworkState{
-    fn update(&mut self){
+impl State for EpidemicNetworkState {
+    fn update(&mut self, step: usize) {
         self.field1.update();
+        self.step = step;
     }
 }

--- a/virusnetwork/src/visualization/mod.rs
+++ b/virusnetwork/src/visualization/mod.rs
@@ -1,2 +1,3 @@
 pub mod vis_state;
 pub mod node;
+pub mod vis_network;

--- a/virusnetwork/src/visualization/node.rs
+++ b/virusnetwork/src/visualization/node.rs
@@ -1,16 +1,15 @@
+use rust_ab::{engine::location::Real2D, visualization::{renderable::{Render, SpriteType}}};
+use rust_ab::bevy::prelude::{Transform, Visible};
+
 use crate::model::node::*;
 use crate::model::state::EpidemicNetworkState;
-use rust_ab::{engine::location::Real2D, visualization::{renderable::{Render, SpriteType}, sprite_render_factory::{SpriteFactoryResource, SpriteRenderFactory}}};
-use rust_ab::bevy::prelude::{Quat, Transform};
-use rust_ab::engine::location::Int2D;
-
 
 impl Render for NetNode {
     fn sprite(&self) -> SpriteType {
-        match self.status{
-            NodeStatus::Susceptible => {SpriteType::Emoji(String::from("white_circle"))}
-            NodeStatus::Infected => {SpriteType::Emoji(String::from("red_circle"))}
-            NodeStatus::Resistent => {SpriteType::Emoji(String::from("large_blue_circle"))}
+        match self.status {
+            NodeStatus::Susceptible => { SpriteType::Emoji(String::from("white_circle")) }
+            NodeStatus::Infected => { SpriteType::Emoji(String::from("red_circle")) }
+            NodeStatus::Resistent => { SpriteType::Emoji(String::from("large_blue_circle")) }
         }
     }
 
@@ -23,7 +22,6 @@ impl Render for NetNode {
             Some(pos) => (pos.x as f32, pos.y as f32, 0.),
             None => (self.pos.x as f32, self.pos.y as f32, 0.),
         }
-        
     }
 
     /// Emojis are 64x64, way too big for our simulation
@@ -37,9 +35,8 @@ impl Render for NetNode {
     }
 
     /// Simply update the transform based on the position chosen
-    fn update(&mut self, transform: &mut Transform, state: &EpidemicNetworkState) {
-        
-        let (pos_x, pos_y, z) = self.position(state);
+    fn update(&mut self, _transform: &mut Transform, state: &EpidemicNetworkState, _visible: &mut Visible) {
+        let (pos_x, pos_y, _z) = self.position(state);
         let model_pos = Real2D {
             x: pos_x as f64,
             y: pos_y as f64,
@@ -47,10 +44,9 @@ impl Render for NetNode {
 
         let node = state.field1.get_objects_at_location(model_pos);
         let node = node.first();
-        
-        if let Some(current_node)  = node{
-            self.status  = current_node.status;
-        }
 
+        if let Some(current_node) = node {
+            self.status = current_node.status;
+        }
     }
 }

--- a/virusnetwork/src/visualization/vis_network.rs
+++ b/virusnetwork/src/visualization/vis_network.rs
@@ -1,0 +1,24 @@
+use rust_ab::bevy::prelude::Color;
+use rust_ab::bevy_canvas::DrawMode;
+use rust_ab::engine::field::network::{Edge, Network};
+use rust_ab::visualization::field::network::{EdgeRenderInfo, LineType, NetworkRender};
+
+use crate::model::epidemic_network::EpidemicNetwork;
+use crate::model::node::NetNode;
+use crate::model::state::EpidemicNetworkState;
+
+impl NetworkRender<NetNode, String, NetNode> for EpidemicNetwork {
+    fn get_network(state: &EpidemicNetworkState) -> &Network<NetNode, String> {
+        &state.network.network
+    }
+
+    fn get_edge_info(edge: &Edge<NetNode, String>) -> EdgeRenderInfo {
+        EdgeRenderInfo {
+            line_color: Color::BLACK,
+            draw_mode: DrawMode::stroke_1px(),
+            source_loc: edge.u.pos,
+            target_loc: edge.v.pos,
+            line_type: LineType::Line,
+        }
+    }
+}

--- a/virusnetwork/src/visualization/vis_state.rs
+++ b/virusnetwork/src/visualization/vis_state.rs
@@ -1,21 +1,19 @@
-use crate::model::{node::*, state::EpidemicNetworkState};
-use crate::{HEIGTH, INITIAL_INFECTED_PROB, INIT_EDGE, NUM_NODES, WIDTH};
-use rust_ab::engine::field::network::*;
+use rust_ab::{
+    bevy::prelude::{Commands, ResMut},
+};
+use rust_ab::{engine::field::network::EdgeOptions::*};
 use rust_ab::engine::location::Real2D;
 use rust_ab::engine::schedule::*;
-use rust_ab::preferential_attachment_BA;
 use rust_ab::rand;
 use rust_ab::rand::Rng;
-use rust_ab::visualization::field::number_grid_2d::BatchRender;
 use rust_ab::visualization::on_state_init::OnStateInit;
 use rust_ab::visualization::renderable::{Render, SpriteType};
 use rust_ab::visualization::simulation_descriptor::SimulationDescriptor;
 use rust_ab::visualization::sprite_render_factory::SpriteFactoryResource;
-use rust_ab::{
-    bevy::prelude::{Commands, ResMut},
-    rand::prelude::ThreadRng,
-};
-use rust_ab::{engine::field::network::EdgeOptions::*, simulate};
+
+use crate::{HEIGTH, INITIAL_INFECTED_PROB, NUM_NODES, WIDTH};
+use crate::model::{node::*, state::EpidemicNetworkState};
+
 pub struct VisState;
 
 impl OnStateInit<NetNode> for VisState {
@@ -27,39 +25,38 @@ impl OnStateInit<NetNode> for VisState {
         mut schedule: ResMut<Schedule<NetNode>>,
         mut sim: ResMut<SimulationDescriptor>,
     ) {
-        let nodes_set = gen_nodes(&mut state, &mut schedule, &mut sprite_render_factory, &mut commands, &mut sim);
+        let nodes_set = gen_nodes(&mut state, &mut schedule, &mut sprite_render_factory, &mut commands);
         let n_nodes = nodes_set.len();
-        state.network.removeAllEdges();
+        state.network.network.remove_all_edges();
 
         if n_nodes == 0 {
             return;
         }
-        state.network.addNode(&nodes_set[0]);
-        state.network.edges.update();
+        state.network.network.add_node(&nodes_set[0]);
+        state.network.network.edges.update();
         if n_nodes == 1 {
             return;
         }
-        state.network.addNode(&nodes_set[1]);
+        state.network.network.add_node(&nodes_set[1]);
 
-        state.network.addEdge(&nodes_set[0], &nodes_set[1], Simple);
-        state.network.edges.update();
+        state.network.network.add_edge(&nodes_set[0], &nodes_set[1], Simple);
+        state.network.network.edges.update();
 
         let init_edge: usize = 1;
 
         for i in 2..n_nodes {
             let node = nodes_set[i];
 
-            state.network.add_prob_edge(&node, &init_edge);
-            state.network.edges.update();
+            state.network.network.add_prob_edge(&node, &init_edge);
+            state.network.network.edges.update();
         }
     }
 }
 
 fn gen_nodes(state: &mut EpidemicNetworkState,
-    schedule: &mut Schedule<NetNode>,
-    sprite_render_factory: &mut SpriteFactoryResource,
-    commands: &mut Commands,
-    sim: &mut SimulationDescriptor
+             schedule: &mut Schedule<NetNode>,
+             sprite_render_factory: &mut SpriteFactoryResource,
+             commands: &mut Commands,
 ) -> Vec<NetNode> {
     //Nodes Generation
 
@@ -85,18 +82,18 @@ fn gen_nodes(state: &mut EpidemicNetworkState,
         );
 
         state.field1.set_object_location(node, node.pos);
-        state.network.addNode(&node);
+        state.network.network.add_node(&node);
         schedule.schedule_repeating(node, 0.0, 0);
 
         let SpriteType::Emoji(emoji_code) = node.sprite();
         let sprite_render = sprite_render_factory.get_emoji_loader(emoji_code);
 
-    
+
         node.setup_graphics(sprite_render, commands, &state);
 
         nodes_set.push(node);
     }
-    let t = state.network.edges.len();
+    let t = state.network.network.edges.len();
     println!("Nodes in the network:\t\t{}", t);
     nodes_set
 }


### PR DESCRIPTION
Reduced the amount of warnings and adds network visualization.

This PR needs https://github.com/rust-ab/rust-ab/pull/15 in order to work.
Screenshot:
![image](https://user-images.githubusercontent.com/11891037/119896647-99da5680-bf3f-11eb-9eb3-5ab29d5cac17.png)
